### PR TITLE
missing dummy entries for all bias related arrays when operator[seq] == opn.NONE

### DIFF
--- a/izer/onnxcp.py
+++ b/izer/onnxcp.py
@@ -798,6 +798,11 @@ def load(  # pylint: disable=R0914
                 output_channels.append(new_size0)
                 weights.append(None)
                 bias.append(None)
+                bias_min.append(0)
+                bias_max.append(0)
+                bias_keys.append("N/A")
+                bias_quant.append(0)
+                bias_size.append(0)
                 quantization.append(None)
                 continue
 


### PR DESCRIPTION
While trying to ai8xize a network with an "op: none" layer I got the following exception:

```
Traceback (most recent call last):
  File "/Users/khp/Dropbox/Projects/Documents/ML/ai8x-synthesis/./ai8xize.py", line 29, in <module>
    main()
  File "/Users/khp/Dropbox/Projects/Documents/ML/ai8x-synthesis/izer/izer.py", line 60, in main
    onnxcp.load(
  File "/Users/khp/Dropbox/Projects/Documents/ML/ai8x-synthesis/izer/onnxcp.py", line 885, in load
    del bias_min[seq - 1]
IndexError: list assignment index out of range
```
Adding dummy entries for all of the bias related arrays when operator[seq] == opn.NONE cleaned up the error.  

The change seems pretty simple/obvious but I'm new to this repo so apologies in advance if I'm off the mark.