### PR TITLE
attempting to reshape w to save_shape on 2nd dense layer with incompatible shape

### DIFF
--- a/izer/onnxcp.py
+++ b/izer/onnxcp.py
@@ -798,6 +798,11 @@ def load(  # pylint: disable=R0914
                 output_channels.append(new_size0)
                 weights.append(None)
                 bias.append(None)
+                bias_min.append(0)
+                bias_max.append(0)
+                bias_keys.append("N/A")
+                bias_quant.append(0)
+                bias_size.append(0)
                 quantization.append(None)
                 continue
 

--- a/izer/onnxcp.py
+++ b/izer/onnxcp.py
@@ -959,6 +959,7 @@ def load(  # pylint: disable=R0914
                                     w = np.reshape(w, save_shape)
                                     w = np.transpose(w, inv(save_perm))
                                     w = np.reshape(w, dense_shape)
+                                    save_perm = []
 
                         input_channels.append(w.shape[t1])  # Input channels
                         output_channels.append(w.shape[t0])  # Output channels


### PR DESCRIPTION
I'm new to this repo so apologies in advance if my change is off the mark.  

I'm working with a network that looks likes this:

```
layers:
- pad: 0
  activate: ReLU
  out_offset: 0x2000
  processors: 0x0000000000000001
  data_format: HWC
  op: conv2d
- pad: 0
  activate: ReLU
  out_offset: 0
  processors: 0xffffffff00000000
  op: conv2d
- max_pool: 2
  pool_stride: 2
  pad: 0
  out_offset: 0x2000
  processors: 0xffffffffffffffff
  op: none
- op: mlp
  flatten: true
  activate: ReLU
  out_offset: 0
  processors: 0xffffffffffffffff
- op: mlp
  out_offset: 0x1000
  activate: ReLU
  processors: 0x00000000ffffffff
```
and the corresponding TF model:
```
model = tf.keras.models.Sequential([
    tf.keras.layers.Input(shape=(32,32,1)),
    ai8xTF.FusedConv2DReLU(
        filters=32, kernel_size=3, strides=1, padding_size=0, pooling=None, use_bias=False),
    ai8xTF.FusedConv2DReLU(
        filters=64, kernel_size=3, strides=1, padding_size=0, pooling=None, use_bias=False),
    ai8xTF.MaxPool2D(pool_size=2),
    tf.keras.layers.Dropout(0.25),
    tf.keras.layers.Flatten(),
    ai8xTF.FusedDenseReLU(
        units=32, use_bias=True, wide=False),
    tf.keras.layers.Dropout(0.5),
    ai8xTF.FusedDenseReLU(
        units=2, use_bias=True, wide=False),
])
```
When I try to ai8xize I get the following exception:
```
Traceback (most recent call last):
  File "/Users/khp/Dropbox/Projects/Documents/ML/ai8x-synthesis/./ai8xize.py", line 29, in <module>
    main()
  File "/Users/khp/Dropbox/Projects/Documents/ML/ai8x-synthesis/izer/izer.py", line 60, in main
    onnxcp.load(
  File "/Users/khp/Dropbox/Projects/Documents/ML/ai8x-synthesis/izer/onnxcp.py", line 959, in load
    w = np.reshape(w, save_shape)
  File "<__array_function__ internals>", line 5, in reshape
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/numpy/core/fromnumeric.py", line 298, in reshape
    return _wrapfunc(a, 'reshape', newshape, order=order)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/numpy/core/fromnumeric.py", line 57, in _wrapfunc
    return bound(*args, **kwds)
ValueError: cannot reshape array of size 64 into shape (14,14,64)
```
It looks as though onnxcp.py is trying to reshape the weights for the last layer to match the save_perm/save_shape arrays that were determined up front in the call to track_data_shape().  Clearing the save_perm array array after it's used the first time resolves the issue but I'm guessing a deeper fix is needed.