### PR TITLE
Fix deprecation warning, use MXC_NVIC_SetVector

### DIFF
--- a/izer/toplevel.py
+++ b/izer/toplevel.py
@@ -455,7 +455,7 @@ def main(
             if embedded_code or embedded_arm or tc.dev.MODERN_SIM:
                 memfile.write('  MXC_SYS_ClockEnable(MXC_SYS_PERIPH_CLOCK_SMPHR); '
                               '// Enable Sempahore clock\n'
-                              '  NVIC_SetVector(RISCV_IRQn, WakeISR); // Set wakeup ISR\n')
+                              '  MXC_NVIC_SetVector(RISCV_IRQn, WakeISR); // Set wakeup ISR\n')
                 if (embedded_code or embedded_arm) and debugwait:
                     memfile.write('\n  // DO NOT DELETE THIS LINE:\n'
                                   f'  MXC_Delay(SEC({debugwait})); '
@@ -579,7 +579,7 @@ def main(
                         '// Enable CNN clock\n\n')
 
             if not riscv:
-                mfile.write('  NVIC_SetVector(CNN_IRQn, CNN_ISR); '
+                mfile.write('  MXC_NVIC_SetVector(CNN_IRQn, CNN_ISR); '
                             '// Set CNN complete vector\n')
             else:
                 mfile.write('  // Set CNN complete vector\n'


### PR DESCRIPTION
This PR updates the izer tool to generate code with `MXC_NVIC_SetVector` instead of `NVIC_SetVector`.

`NVIC_SetVector` was deprecated in the last release.  Code that uses this function will still compile, but with a deprecation warning:

```shell
cnn.c:1212:3: warning: 'NVIC_SetVector' is deprecated: Use MXC_NVIC_SetVector instead.  See nvic_table.h for more details. [-Wdeprecated-declarations]
 1212 |   NVIC_SetVector(CNN_IRQn, CNN_ISR); // Set CNN complete vector
      |   ^~~~~~~~~~~~~~
In file included from /home/jakecarter/repos/msdk/Libraries/PeriphDrivers/Include/MAX78000/mxc.h:51,
                 from cnn.c:66:
/home/jakecarter/repos/msdk/Libraries/PeriphDrivers/Include/MAX78000/nvic_table.h:74:5: note: declared here
   74 |     NVIC_SetVector(IRQn_Type irqn, void (*irq_callback)(void))
      |     ^~~~~~~~~~~~~~
```