### PR TITLE
Fix off-by-one in cnn_unload() stride for wide 32-bit output

### DIFF
--- a/izer/unload.py
+++ b/izer/unload.py
@@ -423,7 +423,7 @@ def unload(
                                 out_text += f'{prefix}  *out_buf++ = *addr++;\n'
                             if delta_r != 4:
                                 out_text += f'{prefix}  addr {"+" if delta_r >= 0 else "-"}= ' \
-                                            f'0x{abs(delta_r) // 4:04x};\n'
+                                            f'0x{abs(delta_r) // 4 - 1:04x};\n'
                         if loop_runs > 1:
                             out_text += '  }\n'
                         remaining -= loop_runs * chunk


### PR DESCRIPTION
When generating cnn_unload() for output_width=32 layers with spatial dimensions > 1x1, the address stride was computed as:

    addr += abs(delta_r) // 4

This produces a 5-word (0x14 byte) stride because *addr++ already advances by 1 word. The correct skip is (delta_r // 4) - 1, giving a 4-word (0x10 byte) stride that matches the hardware SRAM layout.

The bug is invisible for 1x1 spatial output (all existing examples) since the stride is never exercised in that case.

Fix: change abs(delta_r) // 4 to abs(delta_r) // 4 - 1